### PR TITLE
Add Swagger dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,18 +28,26 @@
     </scm>
     <properties>
         <java.version>17</java.version>
+
+        <springdoc-openapi-starter-webmvc-ui.version>2.5.0</springdoc-openapi-starter-webmvc-ui.version>
+        <swagger-parser.version>2.0.31</swagger-parser.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
+
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -53,7 +61,36 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Swagger dependencies -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>${swagger-parser.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version> <!-- A compatible version for swagger-parser -->
+        </dependency>
+        <!-- end of Swagger dependencies -->
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -66,19 +103,7 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
+        <!-- end of Test dependencies -->
     </dependencies>
 
     <build>

--- a/src/main/java/com/francislainy/sobe/OpenApiConfig.java
+++ b/src/main/java/com/francislainy/sobe/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.francislainy.sobe;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    
+    @Bean
+    public OpenAPI customOpenAPI() {
+        OpenAPI openAPI = new OpenAPIV3Parser()
+            .read("src/main/resources/openapi.yml");
+        if (openAPI == null) {
+            throw new IllegalStateException("Failed to parse OpenAPI file.");
+        }
+        return openAPI;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,8 @@ spring.datasource.password=postgres
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.sql.init.mode=always
+
+# OpenAPI
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.url=/v3/api-docs.yaml

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.1
+info:
+  title: SO (Stack Overflow clone) API
+  description: This is a clone of Stack Overflow, providing a platform for users to ask and answer technical questions.
+  version: 1.0.0
+paths:
+  /api/v1/auth/register:
+    post:
+      summary: Register a new user
+      description: This endpoint allows you to register a new user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+      responses:
+        '201':
+          description: User created successfully
+        '400':
+          description: Bad request
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string


### PR DESCRIPTION
Based on:

https://www.baeldung.com/spring-rest-openapi-documentation

https://medium.com/xgeeks/api-first-using-openapi-and-spring-boot-2602c04bb0d3

https://chatgpt.com/c/672ae4c0-bf04-800f-b7f0-2aa7cf6f202b


It's worth noting that as soon as the swagger springdoc-openapi-starter-webmvc-ui is added to the pom file, swagger is already enabled, but adding the extra configuration class and yml file allows more granularity and cleaner code.